### PR TITLE
[config.txt] disable overscan

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -8,3 +8,4 @@ device_tree_address=0x1f0000
 device_tree_end=0x200000
 device_tree=bcm2711-rpi-4-b.dtb
 dtoverlay=miniuart-bt
+disable_overscan=1


### PR DESCRIPTION
Overscan is not required on HDMI displays, so disable it to get rid of the annoying black borders.