### PR TITLE
Running upstream linux kernels should have the upstream overlay enabled

### DIFF
--- a/.github/workflows/linux_edk2.yml
+++ b/.github/workflows/linux_edk2.yml
@@ -84,8 +84,9 @@ jobs:
         curl -O -L ${{ env.RPI_FIRMWARE_URL }}/raw/${{ env.DTB_VERSION }}/boot/bcm2711-rpi-cm4.dtb
         curl -O -L ${{ env.RPI_FIRMWARE_URL }}/raw/${{ env.DTB_VERSION }}/boot/bcm2711-rpi-400.dtb
         curl -O -L ${{ env.RPI_FIRMWARE_URL }}/raw/${{ env.DTBO_VERSION }}/boot/overlays/miniuart-bt.dtbo
+        curl -O -L ${{ env.RPI_FIRMWARE_URL }}/raw/${{ env.DTBO_VERSION }}/boot/overlays/upstream-pi4.dtbo
         mkdir overlays
-        mv miniuart-bt.dtbo overlays
+        mv *.dtbo overlays
 
     - name: Create UEFI firmware archive
       run: zip -r RPi4_UEFI_Firmware_${{ steps.set_version.outputs.version }}.zip RPI_EFI.fd *.dtb config.txt fixup4.dat start4.elf overlays Readme.md firmware

--- a/config.txt
+++ b/config.txt
@@ -8,3 +8,4 @@ disable_overscan=1
 device_tree_address=0x1f0000
 device_tree_end=0x200000
 dtoverlay=miniuart-bt
+dtoverlay=upstream-pi4


### PR DESCRIPTION
So, we should really include the upstream-pi4 overlay, which enables things like the vc4 GPU driver (currently broken) in mainline linux.

This is basically an untested workflow at the moment, the pull request is here because I'm not sure what this will break. It works fine in fedora, but...


Signed-off-by: Jeremy Linton <lintonrjeremy@gmail.com>