### PR TITLE
Add some dtoverlays to enable more DRM/KMS support

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -9,3 +9,5 @@ device_tree_address=0x1f0000
 device_tree_end=0x200000
 dtoverlay=miniuart-bt
 dtoverlay=upstream-pi4
+dtoverlay=vc4-kms-v3d-pi4
+max_framebuffers=2


### PR DESCRIPTION
When installing fedora with previous config, only fbdev is available,
which is restrictive in a modern Linux distro with many applications
no longer supporting fbdev.