### PR TITLE
Add arm_boost=1 so that newer pi4 boards will run at 1.8GHz

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -1,3 +1,4 @@
+arm_boost=1
 arm_64bit=1
 enable_uart=1
 uart_2ndstage=1


### PR DESCRIPTION
This flag was added to default Raspberry Pi OS config.txt last year. I say we should add it here for a bit of extra speed out of the box on Pi boards that support it.

Read more about this here: https://www.raspberrypi.com/news/bullseye-bonus-1-8ghz-raspberry-pi-4/