### PR TITLE
CI: Use actions/checkout to get submodules

### DIFF
--- a/.github/workflows/linux_edk2.yml
+++ b/.github/workflows/linux_edk2.yml
@@ -3,7 +3,7 @@
 
 name: UEFI firmware - EDK2 build
 
-on:  
+on:
   push:
     tags:
       - '*'
@@ -35,10 +35,9 @@ jobs:
         sudo apt-get install acpica-tools gcc-aarch64-linux-gnu
 
     - name: Check out EDK2 repositories
-      uses: actions/checkout@v2
-
-    - name: Check out EDK2 submodules
-      run: git submodule update --init --recursive
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
 
     - name: Patch EDK2 repositories
       run: |


### PR DESCRIPTION
The 'submodules' option also shallow clones the git submodules
which reduces some time. Also bump the checkout actions version.